### PR TITLE
Added the `silent` option.

### DIFF
--- a/lib/rake-progressbar.rb
+++ b/lib/rake-progressbar.rb
@@ -3,7 +3,7 @@
 class RakeProgressbar
   attr_accessor :maximal, :actual, :cols, :finish, :started, :percent, :last_percent, :last_time_dif, :silent
 
-  def initialize(maximal)
+  def initialize(maximal, silence = false)
     if maximal.nil? || maximal < 1
       return nil
     else
@@ -14,7 +14,7 @@ class RakeProgressbar
       self.cols = detect_terminal_size[0] - 3 if detect_terminal_size
       self.cols = 80 if self.cols.nil? || self.cols < 80
       self.finish = false
-      self.silent = false
+      self.silent = silence
       if maximal == 0
         puts "nothing to do"
       else

--- a/lib/rake-progressbar.rb
+++ b/lib/rake-progressbar.rb
@@ -1,7 +1,7 @@
 # -*- encoding : utf-8 -*-
 
 class RakeProgressbar
-  attr_accessor :maximal, :actual, :cols, :finish, :started, :percent, :last_percent, :last_time_dif
+  attr_accessor :maximal, :actual, :cols, :finish, :started, :percent, :last_percent, :last_time_dif, :silent
 
   def initialize(maximal)
     if maximal.nil? || maximal < 1
@@ -14,6 +14,7 @@ class RakeProgressbar
       self.cols = detect_terminal_size[0] - 3 if detect_terminal_size
       self.cols = 80 if self.cols.nil? || self.cols < 80
       self.finish = false
+      self.silent = false
       if maximal == 0
         puts "nothing to do"
       else
@@ -35,6 +36,10 @@ class RakeProgressbar
   end
 
   def display
+    if self.silent
+      return nil
+    end
+
     time_dif = ((Time.now - self.started)).to_i
     if self.percent == 0
       remaining = 0
@@ -68,13 +73,17 @@ class RakeProgressbar
       if self.maximal != 0
         display
       end
-      STDOUT.print "\n"
-      if show_actual
-        STDOUT.print "Finished #{self.actual} in #{Time.now - self.started}s\n"
-      else
-        STDOUT.print "Finished in #{Time.now - self.started}s\n"
+
+      unless self.silent
+        STDOUT.print "\n"
+        if show_actual
+          STDOUT.print "Finished #{self.actual} in #{Time.now - self.started}s\n"
+        else
+          STDOUT.print "Finished in #{Time.now - self.started}s\n"
+        end
+        STDOUT.flush
       end
-      STDOUT.flush
+
       self.finish = true
     end
   end

--- a/rake-progressbar.gemspec
+++ b/rake-progressbar.gemspec
@@ -5,7 +5,7 @@
 
 Gem::Specification.new do |s|
   s.name = "rake-progressbar"
-  s.version = "0.0.5"
+  s.version = "0.0.6"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Ondrej Bartas"]


### PR DESCRIPTION
If you want to create an instance of `RakeProgressbar` but, at the same time, opt out of it actually displaying the progress in the terminal, now you can do something like this:

``` ruby
bar = RakeProgressbar.new(100)
bar.silent = true # <=
100.times do 
 bar.inc # nothing is printed in the terminal
end
bar.finished
```

It might be useful if you want to make the progress bar optional. So, you'd just create an object and set the `silent` property to either true or false depending on whether it's supposed to be silent or not.

Thanks!
